### PR TITLE
Configure GitHub Pages deployment and AWS backend settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Pymeflowec Frontend
+
+Frontend Angular listo para desplegar en **GitHub Pages** y consumir un backend ya publicado en **AWS**.
+
+## 1) Configurar la URL real de tu backend AWS
+
+Edita este archivo:
+
+- `src/environments/environment.prod.ts`
+
+Y cambia `apiUrl` por tu endpoint real (API Gateway, ALB o dominio propio):
+
+```ts
+apiUrl: 'https://TU-ENDPOINT-AWS/api'
+```
+
+> Importante: usa `https://` para evitar bloqueos de contenido mixto cuando el front esté en GitHub Pages.
+
+## 2) Build para GitHub Pages
+
+Este repo incluye un script preparado para publicar bajo la ruta del repositorio `/pymeflowec-front/`:
+
+```bash
+npm install
+npm run build:gh-pages
+```
+
+La salida queda en:
+
+- `dist/pymeflowec-frontend/browser`
+
+## 3) Activar GitHub Pages
+
+1. Ve a **Settings → Pages** en tu repo de GitHub.
+2. En **Build and deployment**, selecciona **Deploy from a branch**.
+3. Publica el contenido de la carpeta de build (por ejemplo en rama `gh-pages` o con GitHub Actions).
+
+URL esperada del frontend:
+
+- `https://<tu-usuario>.github.io/pymeflowec-front/`
+
+## 4) Checklist AWS (backend)
+
+- Permite CORS para el origen exacto de GitHub Pages:
+  - `https://<tu-usuario>.github.io`
+- Habilita métodos y headers necesarios (`Authorization`, `Content-Type`, etc.).
+- Responde preflight `OPTIONS` correctamente.
+- Verifica que tus rutas API coincidan con el prefijo configurado en `apiUrl`.
+
+## Notas de enrutado
+
+Se habilitó **hash routing** (`/#/ruta`) para evitar errores 404 al recargar rutas internas en GitHub Pages.
+
+## Desarrollo local
+
+```bash
+npm install
+npm start
+```
+
+Por defecto local:
+
+- `src/environments/environment.ts`
+- `http://localhost:8080/api`

--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "optimization": {
                 "scripts": true,
                 "styles": true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "ng serve --port 5173",
     "build": "ng build",
+    "build:gh-pages": "ng build --configuration production --base-href /pymeflowec-front/",
     "watch": "ng build --watch --configuration development"
   },
   "dependencies": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withHashLocation } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { importProvidersFrom } from '@angular/core';
@@ -30,7 +30,7 @@ function spanishPaginatorIntl(): MatPaginatorIntl {
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideRouter(routes),
+    provideRouter(routes, withHashLocation()),
     provideHttpClient(withInterceptors([tokenInterceptor, errorInterceptor])),
     provideAnimationsAsync(),
     importProvidersFrom(MatSnackBarModule, MatDialogModule),

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:8080/api'
+  // URL de tu backend en AWS (API Gateway/ALB), siempre con HTTPS.
+  apiUrl: 'https://TU-ENDPOINT-AWS/api'
 };


### PR DESCRIPTION
### Motivation
- Prepare the Angular frontend to be deployed on GitHub Pages so assets and routes load correctly under the repository subpath.
- Integrate with an already-deployed backend on AWS by providing a clear production environment entry for the API URL using HTTPS.
- Prevent runtime routing 404s on GitHub Pages by using a routing strategy that does not require server-side route handling.

### Description
- Added `build:gh-pages` script in `package.json` to run `ng build --configuration production --base-href /pymeflowec-front/` for GitHub Pages builds.
- Enabled hash routing by changing the router provider to `provideRouter(routes, withHashLocation())` in `src/app/app.config.ts` to avoid 404s on page reloads.
- Updated `src/environments/environment.prod.ts` to include an HTTPS placeholder `apiUrl` for the AWS backend and ensured `fileReplacements` is configured in `angular.json` for production builds.
- Rewrote `README.md` with instructions for configuring the AWS endpoint, building for GitHub Pages, enabling Pages, and an AWS CORS/preflight checklist.

### Testing
- Executed `npm run build` and the production build completed successfully with output in `dist/pymeflowec-frontend` but showed existing warnings about bundle budget and a CommonJS dependency (`apexcharts`).
- Executed `npm run build:gh-pages` and the build completed successfully with output for GH Pages and the same non-blocking warnings about bundle budget and CommonJS usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc2fa3aac8322aeaf4c3e99606a53)