### PR TITLE
Fix GitHub Pages workflow for Angular deployment

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,44 +1,46 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy Angular app to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Angular app
+        run: npm run build
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist/pymeflowec-frontend/browser
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Angular app to GitHub Pages
+name: Deploy Angular app to gh-pages branch
 
 on:
   push:
@@ -6,16 +6,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,21 +27,9 @@ jobs:
       - name: Build Angular app
         run: npm run build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: ./dist/pymeflowec-frontend/browser
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/pymeflowec-frontend/browser
+          publish_branch: gh-pages


### PR DESCRIPTION
### Motivation
- The repository contains an Angular application but the CI workflow was configured for a Jekyll site, causing the Pages `build` job to fail and the deployment to be skipped.
- The change aims to run the appropriate Node/Angular build steps so the artifact uploaded to GitHub Pages is the actual Angular build output.

### Description
- Updated `.github/workflows/jekyll-gh-pages.yml` to an Angular-focused workflow and renamed it to reflect the Angular deployment.
- Added Node setup using `actions/setup-node@v4` with `node-version: 20` and enabled the npm cache.
- Added `npm ci` and `npm run build` steps to produce the production build before packaging.
- Changed the uploaded Pages artifact path to `./dist/pymeflowec-frontend/browser` so the deployment uses the Angular build output.

### Testing
- Ran `npm ci` successfully to install dependencies without errors.
- Ran `npm run build` successfully and produced the app bundle in `dist/pymeflowec-frontend/browser`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e047294648832298ad7c07144e193d)